### PR TITLE
Render template to a file

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -69,9 +69,10 @@ type Arguments struct {
 	DataRoot     string
 	SchemaPath   string
 	TemplatePath string
+	OutputPath   string
 }
 
-func NewArguments(dataRoot string, schemaPath string, templatePath string) (Arguments, error) {
+func NewArguments(dataRoot string, schemaPath string, templatePath string, outputPath string) (Arguments, error) {
 	dataRoot = strings.TrimSpace(dataRoot)
 	if dataRoot == "" {
 		return Arguments{}, errors.New("dataRoot is required")
@@ -84,7 +85,12 @@ func NewArguments(dataRoot string, schemaPath string, templatePath string) (Argu
 		return Arguments{}, errors.New("templatePath is required")
 	}
 
-	return Arguments{DataRoot: dataRoot, SchemaPath: schemaPath, TemplatePath: templatePath}, nil
+	outputPath = strings.TrimSpace(outputPath)
+	if outputPath == "" {
+		return Arguments{}, errors.New("outputPath is required")
+	}
+
+	return Arguments{DataRoot: dataRoot, SchemaPath: schemaPath, TemplatePath: templatePath, OutputPath: outputPath}, nil
 }
 
 func findAllMatchingFilePaths(root string, pattern *regexp.Regexp, appFs afero.Fs) ([]string, error) {

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"html/template"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -53,7 +52,7 @@ func Execute(args Arguments) error {
 		}
 	}
 
-	err = tmpl.Execute(os.Stdout, templateData{ParsedData: parsedFiles})
+	err = renderTemplateToPath(tmpl, templateData{ParsedData: parsedFiles}, args.OutputPath, appFs)
 	if err != nil {
 		return err
 	}
@@ -199,4 +198,16 @@ func readTemplate(templatePath string, appFs afero.Fs) (*template.Template, erro
 	}
 
 	return tmpl, err
+}
+
+func renderTemplateToPath(tmpl *template.Template, data templateData, path string, appFs afero.Fs) error {
+	file, err := appFs.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	err = tmpl.Execute(file, data)
+
+	return err
 }

--- a/main.go
+++ b/main.go
@@ -22,8 +22,9 @@ func parseArguments() (commands.Arguments, error) {
 	dataRoot := flag.String("dataRoot", "", "Directory that contains data files.")
 	schemaPath := flag.String("schema", "", "Optional JSON schema used to validate data.")
 	templatePath := flag.String("template", "", "Template that is used to render data.")
+	outputPath := flag.String("output", "", "File path where the rendered template is written to.")
 
 	flag.Parse()
 
-	return commands.NewArguments(*dataRoot, *schemaPath, *templatePath)
+	return commands.NewArguments(*dataRoot, *schemaPath, *templatePath, *outputPath)
 }


### PR DESCRIPTION
An output path can be given to which the applied template
is rendered to.

Closes #4 and #5 